### PR TITLE
fixing bad import

### DIFF
--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -2,7 +2,7 @@ import requests
 import time as Time
 import threading
 
-from forecastio import Forecast
+from models import Forecast
 
 
 def load_forecast(key, inLat, inLong, time=None, units="auto", lazy=False,


### PR DESCRIPTION
Looks like you forgot this when you did your big rename? This is what you would see when you tried to run the example without this change:

[master:?][bwilliams@bobot:~/Projects/python-forcast.io]
[17:27:31] $ python example.py
Traceback (most recent call last):
  File "example.py", line 1, in <module>
    import forecastio
  File "/Users/bwilliams/Projects/python-forcast.io/forecastio/**init**.py", line 1, in <module>
    from api import load_forecast
  File "/Users/bwilliams/Projects/python-forcast.io/forecastio/api.py", line 5, in <module>
    from forecastio import Forecast
ImportError: cannot import name Forecast
