### PR TITLE
versions of requests prior to this throw an error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     packages=['forecastio'],
     package_data={'forecastio': ['LICENSE.txt', 'README.rst']},
     long_description=open('README.rst').read(),
-    install_requires=['requests'],
+    install_requires=['requests>=1.6'],
 )


### PR DESCRIPTION
example script dies trying to access content.json() as it is not a dict.
minor bit, but may help with folks who try to implement things in stable environments.
