### PR TITLE
Support for naïve datetime objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dist
 test.py
 MANIFEST
+build/
+python_forecastio.egg-info/

--- a/example.py
+++ b/example.py
@@ -1,15 +1,19 @@
-import forecastio
 import datetime
+import forecastio
 
 
 def main():
-
+    """
+    Run load_forecast() with the given lat, lng, and time arguments.
+    """
 
     api_key = "YOUR API KEY"
-    lat = -31.967819
-    lng = 115.87718
 
-    forecast = forecastio.load_forecast(api_key, lat, lng)
+    lat  = -31.967819
+    lng  = 115.87718
+    time = datetime.datetime.now()
+
+    forecast = forecastio.load_forecast(api_key, lat, lng, time=time)
 
     print forecast.hourly().data[0].temperature
     print "===========Hourly Data========="

--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -26,7 +26,7 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
         url = 'https://api.forecast.io/forecast/%s/%s,%s' \
               '?units=%s' % (key, lat, lng, units,)
     else:
-        url_time = time.isoformat()
+        url_time = time.replace(microsecond=0).isoformat()  # API returns 400 for microseconds
         url = 'https://api.forecast.io/forecast/%s/%s,%s,%s' \
               '?units=%s' % (key, lat, lng, url_time,
               units,)

--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -43,7 +43,7 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
 
 def manual(requestURL, callback=None):
     """
-        This fnction is used by load_forecast OR by users to manually
+        This function is used by load_forecast OR by users to manually
         construct the URL for an API call.
     """
 

--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -1,5 +1,4 @@
 import requests
-import time as Time
 import threading
 
 from forecastio.models import Forecast
@@ -14,7 +13,8 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
         inLat:  The latitude of the forecast
         inLong: The longitude of the forecast
         time:   A datetime.datetime object representing the desired time of
-                the forecast
+               the forecast. If no timezone is present, the API assumes local
+               time at the provided latitude and longitude.
         units:  A string of the preferred units of measurement, "auto" id
                 default. also us,ca,uk,si is available
         lazy:   Defaults to false.  The function will only request the json
@@ -26,7 +26,7 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
         url = 'https://api.forecast.io/forecast/%s/%s,%s' \
               '?units=%s' % (key, lat, lng, units,)
     else:
-        url_time = str(int(Time.mktime(time.timetuple())))
+        url_time = time.isoformat()
         url = 'https://api.forecast.io/forecast/%s/%s,%s,%s' \
               '?units=%s' % (key, lat, lng, url_time,
               units,)
@@ -43,7 +43,7 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
 
 def manual(requestURL, callback=None):
     """
-        This fuction is used by load_forecast OR by users to manually
+        This fnction is used by load_forecast OR by users to manually
         construct the URL for an API call.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     packages=['forecastio'],
     package_data={'forecastio': ['LICENSE.txt', 'README.rst']},
     long_description=open('README.rst').read(),
-    install_requires=['requests>=1.6'],
+    install_requires=['requests>=1.6', 'responses'],
 )


### PR DESCRIPTION
Ref [Issue 21](https://github.com/ZeevG/python-forecast.io/issues/21#issuecomment-92179248). 

The `.load_forecast()` method is currently converting the datetime argument to seconds since the epoch in *local* time, which has the effect of making it an "aware" datetime. That is, it imbues the datetime with statefulness w.r.t. location that it doesn't necessarily have already, if it's passed as a naïve datetime (i.e. "5 o'clock somewhere", not necessarily "5 o'clock in Greenwich.")

Technically, the issue is that `time.mktime()` takes an argument in *local* time (i.e. the locale of my laptop) and converts to seconds since the epoch (docs). In the API though, they expect a naïve datetime, unless timezone is specified. From the API docs:

*For the latter format, if no timezone is present, local time (at the provided latitude and longitude) is assumed. (This string format is a subset of ISO 8601 time. An as example, `2013-05-06T12:00:00-0400`.)*

My thought was, that in order to make the wrapper as thin as possible, that it should behave in the same way. Instead of using `mktime()`, it should use `isoformat()`.

```
In [1]: %paste
import time
import datetime
from delorean import Delorean

## -- End pasted text --

In [2]: d = datetime.datetime(2015, 4, 11, 2, 45)  # initialized without any tzinfo

In [3]: d.isoformat()  # this format has no tzinfo, is naïvely unaware of location
Out[3]: '2015-04-11T02:45:00'

In [4]: ep = time.mktime(d.timetuple())

In [5]: ep  # this number is only associated with datetime(2015, 4, 11, 2, 45) in the sense of GMT-04:00 (I'm in New York.) So it's no longer naïve to location.
Out[5]: 1428734700.0

In [6]: dl = Delorean(d, timezone="US/Mountain")  # use delorean to create a timezone-aware datetime.datetime

In [7]: dl.datetime  
Out[7]: datetime.datetime(2015, 4, 11, 2, 45, tzinfo=<DstTzInfo 'US/Mountain' MDT-1 day, 18:00:00 DST>)

In [8]: dl.datetime.isoformat()  # in this case timezone info would be passed on to the API.
Out[8]: '2015-04-11T02:45:00-06:00'
```