### PR TITLE
models.py datetime object modification

### DIFF
--- a/forecastio/models.py
+++ b/forecastio/models.py
@@ -81,20 +81,20 @@ class ForecastioDataPoint(UnicodeMixin):
         self.d = d
 
         try:
-            self.time = datetime.datetime.fromtimestamp(int(d['time']))
+            self.time = datetime.datetime.utcfromtimestamp(int(d['time']))
             self.utime = d['time']
         except:
             pass
 
         try:
             sr_time = int(d['sunriseTime'])
-            self.sunriseTime = datetime.datetime.fromtimestamp(sr_time)
+            self.sunriseTime = datetime.datetime.utcfromtimestamp(sr_time)
         except:
             self.sunriseTime = None
 
         try:
             ss_time = int(d['sunsetTime'])
-            self.sunsetTime = datetime.datetime.fromtimestamp(ss_time)
+            self.sunsetTime = datetime.datetime.utcfromtimestamp(ss_time)
         except:
             self.sunsetTime = None
 


### PR DESCRIPTION
Modify models.py such that returned datetime objects do not have the local timezone appended to historic requests