### PR TITLE
return None instead of throwing PropertyUnavailable exception

### DIFF
--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -4,7 +4,7 @@ import threading
 from forecastio.models import Forecast
 
 
-def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
+def load_forecast(key, lat, lng, time=None, units="auto", lang="en", lazy=False,
                   callback=None):
     """
         This function builds the request url and loads some or all of the
@@ -24,12 +24,12 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
 
     if time is None:
         url = 'https://api.forecast.io/forecast/%s/%s,%s' \
-              '?units=%s' % (key, lat, lng, units,)
+              '?units=%s&lang=%s' % (key, lat, lng, units, lang)
     else:
         url_time = time.replace(microsecond=0).isoformat()  # API returns 400 for microseconds
         url = 'https://api.forecast.io/forecast/%s/%s,%s,%s' \
-              '?units=%s' % (key, lat, lng, url_time,
-              units,)
+              '?units=%s&lang=%s' % (key, lat, lng, url_time,
+              units, lang)
 
     if lazy is True:
         baseURL = "%s&exclude=%s" % (url,

--- a/forecastio/models.py
+++ b/forecastio/models.py
@@ -102,10 +102,7 @@ class ForecastioDataPoint(UnicodeMixin):
         try:
             return self.d[name]
         except KeyError:
-            raise PropertyUnavailable(
-                "Property '{}' is not valid"
-                " or is not available for this forecast".format(name)
-            )
+            return None
 
     def __unicode__(self):
         return '<ForecastioDataPoint instance: ' \
@@ -120,10 +117,7 @@ class Alert(UnicodeMixin):
         try:
             return self.json[name]
         except KeyError:
-            raise PropertyUnavailable(
-                "Property '{}' is not valid"
-                " or is not available for this forecast".format(name)
-            )
+            return None
 
     def __unicode__(self):
         return '<Alert instance: {0} at {1}>'.format(self.title, self.time)


### PR DESCRIPTION
Why throw an exception instead of returning None? These fields may be empty very often and dealing with None is easier
