### PR TITLE
Add timeout to prevent API calls from never returning

### DIFF
--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -56,7 +56,7 @@ def manual(requestURL, callback=None):
 
 
 def get_forecast(requestURL):
-    forecastio_reponse = requests.get(requestURL)
+    forecastio_reponse = requests.get(requestURL, timeout=10)
     forecastio_reponse.raise_for_status()
 
     json = forecastio_reponse.json()


### PR DESCRIPTION
This PR adds a 10 second timeout to prevent requests from staying open forever.