### PR TITLE
Add method to access timezone and update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ How Timezones Work
 ------------------
 Requests with a naive datetime (no time zone specified) will correspond to the supplied time in the requesting location. If a timezone aware datetime object is supplied, the supplied time will be in the associated timezone.
 
-Returned times eg the time parameter on the currently DataPoint are always in UTC time even if making a request with a timezone. If you want to manually convert to the locations local time, you can use the `offset` and `timezone` attributes of the forecast object.
+Returned times eg the time parameter on the currently DataPoint are always in UTC time even if making a request with a timezone. If you want to manually convert to the locations local time, you can use the `timezone` and `offset` methods of the forecast object.
 
 Typically, would would want to do something like this:
 

--- a/forecastio/models.py
+++ b/forecastio/models.py
@@ -31,6 +31,9 @@ class Forecast(UnicodeMixin):
     def daily(self):
         return self._forcastio_data('daily')
 
+    def timezone(self):
+        return self.json['timezone']
+
     def offset(self):
         return self.json['offset']
 


### PR DESCRIPTION
A method has been added that returns the timezone for the given location.
- Usage: `tz_str = forecast.timezone()`.

`README.rst` has been updated accordingly.