### PR TITLE
Added language parameter to support i18n of Dark Sky API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ Parameters:
 	- **latitude** - The latitude of the location for the forecast
 	- **longitude** - The longitude of the location for the forecast
 	- **time** - (optional) A datetime object for the forecast either in the past or future - see How Timezones Work below for the details on how timezones are handled in this library.
+	- **lang** - (optional) A string of the desired language. See https://darksky.net/dev/docs/time-machine for supported languages.
 	- **units** - (optional) A string of the preferred units of measurement, "auto" is the default. "us","ca","uk","si" are also available. See the API Docs (https://darksky.net/dev/docs/forecast) for exactly what each unit means.
 	- **lazy** - (optional) Defaults to `false`.  If `true` the function will request the json data as it is needed. Results in more requests, but maybe a faster response time.
 	- **callback** - (optional) Pass a function to be used as a callback. If used, load_forecast() will use an asynchronous HTTP call and **will not return the forecast object directly**, instead it will be passed to the callback function. Make sure it can accept it.

--- a/example.py
+++ b/example.py
@@ -11,9 +11,10 @@ def main():
 
     lat = -31.967819
     lng = 115.87718
-    time = datetime.datetime(2015, 2, 27, 6, 0, 0)
+    lang = "de"
+    time = datetime.datetime.now()
 
-    forecast = forecastio.load_forecast(api_key, lat, lng, time=time)
+    forecast = forecastio.load_forecast(api_key, lat, lng, lang=lang, time=time)
 
     print "===========Currently Data========="
     print forecast.currently()

--- a/forecastio/api.py
+++ b/forecastio/api.py
@@ -4,7 +4,7 @@ import threading
 from forecastio.models import Forecast
 
 
-def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
+def load_forecast(key, lat, lng, time=None, units="auto", lang="en", lazy=False,
                   callback=None):
     """
         This function builds the request url and loads some or all of the
@@ -17,6 +17,7 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
                time at the provided latitude and longitude.
         units:  A string of the preferred units of measurement, "auto" id
                 default. also us,ca,uk,si is available
+        lang:   Return summary properties in the desired language
         lazy:   Defaults to false.  The function will only request the json
                 data as it is needed. Results in more requests, but
                 probably a faster response time (I haven't checked)
@@ -24,12 +25,12 @@ def load_forecast(key, lat, lng, time=None, units="auto", lazy=False,
 
     if time is None:
         url = 'https://api.darksky.net/forecast/%s/%s,%s' \
-              '?units=%s' % (key, lat, lng, units,)
+              '?units=%s&lang=%s' % (key, lat, lng, units, lang,)
     else:
         url_time = time.replace(microsecond=0).isoformat()  # API returns 400 for microseconds
         url = 'https://api.darksky.net/forecast/%s/%s,%s,%s' \
-              '?units=%s' % (key, lat, lng, url_time,
-              units,)
+              '?units=%s&lang=%s' % (key, lat, lng, url_time,
+              units, lang,)
 
     if lazy is True:
         baseURL = "%s&exclude=%s" % (url,

--- a/tests/test_forecastio.py
+++ b/tests/test_forecastio.py
@@ -19,18 +19,20 @@ class EndToEnd(unittest.TestCase):
 
         self.time = datetime(2015, 2, 27, 6, 0, 0)
 
+        self.lang = "en"
+
     def test_with_time(self):
 
         forecast = forecastio.load_forecast(
             self.api_key, self.lat,
-            self.lng, time=self.time
+            self.lng, time=self.time, lang=self.lang
         )
         self.assertEqual(forecast.response.status_code, 200)
 
     def test_without_time(self):
 
         forecast = forecastio.load_forecast(
-            self.api_key, self.lat, self.lng
+            self.api_key, self.lat, self.lng, lang=self.lang
         )
         self.assertEqual(forecast.response.status_code, 200)
 
@@ -39,7 +41,7 @@ class EndToEnd(unittest.TestCase):
 
         try:
             forecastio.load_forecast(
-                self.api_key, self.lat, self.lng
+                self.api_key, self.lat, self.lng, lang=self.lang
             )
 
             self.assertTrue(False)  # the previous line should throw an exception
@@ -51,7 +53,7 @@ class EndToEnd(unittest.TestCase):
 
         try:
             forecastio.load_forecast(
-                self.api_key, self.lat, self.lng
+                self.api_key, self.lat, self.lng, lang=self.lang
             )
 
             self.assertTrue(False)  # the previous line should throw an exception
@@ -73,7 +75,8 @@ class BasicFunctionality(unittest.TestCase):
         api_key = "foo"
         lat = 50.0
         lng = 10.0
-        self.fc = forecastio.load_forecast(api_key, lat, lng)
+        lang = "en"
+        self.fc = forecastio.load_forecast(api_key, lat, lng, lang=lang)
 
         self.assertEqual(responses.calls[0].request.url, URL)
 


### PR DESCRIPTION
Added the ability to control the language parameter for Dark Sky. This is needed for my modifications for the Home Assistant Dark Sky Sensor where I want to have german weather forecasts :-)
So it would be great if you could release a new version of your library and I'll raise the version of the dependency accordingly in order to finish my Home Assistant pull request.

Thanks!