### PR TITLE
Require responses<=0.23.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     packages=['forecastio'],
     package_data={'forecastio': ['LICENSE.txt', 'README.rst']},
     long_description=open('README.rst').read(),
-    install_requires=['requests>=1.6', 'responses'],
+    install_requires=['requests>=1.6', 'responses<=0.23.1'],
 )


### PR DESCRIPTION
Require responses<=0.23.1 to resolve dependency conflicts introduced by responses 0.23.2 (e.g., with Home Assistant integrations) pending upstream resolution

https://github.com/getsentry/responses/issues/657
https://github.com/home-assistant/core/issues/97248